### PR TITLE
amended rt cleaning for task switch data

### DIFF
--- a/src/run_wrangling.R
+++ b/src/run_wrangling.R
@@ -144,19 +144,19 @@ res <- res %>%
 if (exp=="exp_ts"){
   tmp <- res %>% 
     ungroup() %>% 
-    group_by(sub,ses,context,switch) %>% 
+    group_by(sub,ses,switch) %>% 
+    filter(rt_correct < 4) %>% # v unrealistic upper cutoff
     summarise(
-      mu = mean(rt, na.omit=TRUE),
-      sd = sd(rt)
+      mu = mean(rt_correct, na.omit=TRUE),
+      sd = sd(rt_correct)
     ) %>% 
     mutate(cutoff = mu+2.5*sd) %>% 
     select(!c(mu,sd))
-
+  
   res <- left_join(res,tmp)
   
   res <- res %>% 
-    filter(rt<=10) %>% 
-    filter(rt<=cutoff)
+    filter(rt_correct<=cutoff)
 }
 
 fnl <- file.path(project_path, "res", paste(paste(exp, "trl", sep = "_"), ".csv", sep = ""))


### PR DESCRIPTION
I have amended the RT data cleaning so that it does the following -

filters rt_correct rather than rt (as we need to analyse/present the former, the latter is contaminated with setting errors)

changed order of operations so that it first applies a pass of an unlikely upper cutoff (4 seconds - determined from looking at histogram of all RTs), then it calculates the mean and sd and filters out anything > 2.5 sdevs above the mean.

the code as was written applied the mean + sd filter before the upper cutoff trim, but this results in inaccurate/zero trimming of the RT distributions because the very unlikely RTs [> 4 s, probably due to waiting after a break or something] will inflate both the mean the sd estimates.

Once you have integrated these changes, could you please make a new DOI for the updated version? Much appreciated!